### PR TITLE
Fixed a bug for UTXO

### DIFF
--- a/src/core/blockchain.cr
+++ b/src/core/blockchain.cr
@@ -176,7 +176,7 @@ module ::Sushi::Core
         Transaction.create_id,
         "head",
         senders,
-        miners_recipients.push(node_reccipient),
+        [node_reccipient] + miners_recipients,
         "0", # message
         "0", # prev_hash
         "0", # sign_r


### PR DESCRIPTION
I've fix a following bug.
- The first recipient of the coinbase transaction have to be the node, but previously it was some miner.