### PR TITLE
adding local aliases file for convenience

### DIFF
--- a/sushicoin_profile.sh
+++ b/sushicoin_profile.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# put in your .bash_profile like this
+# source ~/path/to/SushiCoin/sushicoin_profile.sh
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+alias sc="cd $DIR"
+alias sc-unit="sc && crystal spec"
+alias sc-e2e="sc && TRAVIS=true crystal spec"


### PR DESCRIPTION
This is a a few bash aliases for convenience:

you `source` it from your .bash_profile and it gives:

sc = auto cd to SushiCoin dir
sc-unit = run unit tests
sc-e2e = run e2e

If you don't like it - I can always keep it local and add it to .gitignore  