### PR TITLE
Keys

### DIFF
--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -321,6 +321,9 @@ describe Keys do
     end
 
     it "should raise an error if address checksum is not valid" do
+      expect_raises(Exception, "Invalid address checksum for: invalid-address") do
+        Address.new("invalid-address")
+      end
     end
 
     it "should return the network when calling #network" do

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -35,6 +35,16 @@ describe Keys do
       keys = Keys.generate({prefix: "T0", name: "testnet"})
       keys.wif.network.should eq({prefix: "T0", name: "testnet"})
     end
+
+    it "should make an address for mainnet when no network supplied" do
+      keys = Keys.generate
+      keys.address.network.should eq({prefix: "M0", name: "mainnet"})
+    end
+
+    it "should make an address for the specified network" do
+      keys = Keys.generate({prefix: "T0", name: "testnet"})
+      keys.address.network.should eq({prefix: "T0", name: "testnet"})
+    end
   end
 
   describe PublicKey do

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -5,6 +5,28 @@ include Sushi::Core
 include Sushi::Core::Keys
 
 describe Keys do
+  describe "#Keys.generate" do
+    it "should generate a private and public key pair as Key objects" do
+      keys = Keys.generate
+
+      keys.private_key.should be_a(PrivateKey)
+      keys.private_key.as_hex.size.should eq(64)
+
+      keys.public_key.should be_a(PublicKey)
+      keys.public_key.as_hex.size.should eq(128)
+    end
+
+    it "should generate a key pair for the mainnet when no network supplied" do
+      keys = Keys.generate
+      keys.public_key.network.should eq({prefix: "M0", name: "mainnet"})
+    end
+
+    it "should generate a key pair for the specified network" do
+      keys = Keys.generate({prefix: "T0", name: "testnet"})
+      keys.public_key.network.should eq({prefix: "T0", name: "testnet"})
+    end
+  end
+
   describe PublicKey do
     describe "#initialize" do
       it "should create a public key object from a public key string" do
@@ -16,32 +38,21 @@ describe Keys do
         public_key.as_hex.should eq(hex_public_key)
       end
 
-      it "should raise an error if the public key string is not a valid public key" do
+      it "should raise an error if the public key hex string is not a valid public key" do
+        expect_raises(Exception, "Invalid public key: 123") do
+          PublicKey.new("123")
+        end
       end
     end
 
     describe "#from hex" do
       it "should create a public key object from a public key string" do
         secp256k1 = ECDSA::Secp256k1.new
+        key_pair = secp256k1.create_key_pair
+        hex_public_key = key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16)
 
-
-         loop do
-             key_pair = secp256k1.create_key_pair
-             one = key_pair[:public_key].x.to_s(16)
-             p two = key_pair[:public_key].y.to_s(16)
-             sk = key_pair[:secret_key].to_s(16)
-             # p sk.size
-             # p one.size
-             # p two.size
-            hex_public_key = one + two
-            if hex_public_key.hexbytes? == nil
-              puts "is not hex: #{hex_public_key}"
-              break
-            end
-         end
-
-        # public_key = PublicKey.from(hex_public_key)
-        # public_key.as_hex.should eq(hex_public_key)
+        public_key = PublicKey.from(hex_public_key)
+        public_key.as_hex.should eq(hex_public_key)
       end
     end
 
@@ -51,7 +62,7 @@ describe Keys do
         key_pair = secp256k1.create_key_pair
         hex_public_key = key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16)
         hexbytes = hex_public_key.hexbytes
-        # p typeof(hexbytes)
+
         public_key = PublicKey.from(hexbytes)
         public_key.as_bytes.should eq(hexbytes)
         public_key.as_hex.should eq(hex_public_key)
@@ -61,18 +72,61 @@ describe Keys do
     end
 
     it "should convert a public key from hex to bytes with #as_bytes" do
+      secp256k1 = ECDSA::Secp256k1.new
+      key_pair = secp256k1.create_key_pair
+      hex_public_key = key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16)
+      hexbytes = hex_public_key.hexbytes
+
+      public_key = PublicKey.from(hex_public_key)
+      public_key.as_bytes.should eq(hexbytes)
     end
 
     it "should convert a public key from bytes to hex with #as_hex" do
+      secp256k1 = ECDSA::Secp256k1.new
+      key_pair = secp256k1.create_key_pair
+      hex_public_key = key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16)
+      hexbytes = hex_public_key.hexbytes
+
+      public_key = PublicKey.from(hexbytes)
+      public_key.as_hex.should eq(hex_public_key)
     end
 
-    it "should return the address with #address" do
+    describe "#network" do
+      it "should return the mainnet by default" do
+        Keys.generate.public_key.network.should eq({prefix: "M0", name: "mainnet"})
+      end
+      it "should return the supplied network" do
+        Keys.generate({prefix: "T0", name: "testnet"}).public_key.network.should eq({prefix: "T0", name: "testnet"})
+      end
+    end
+
+    describe "#address" do
+      it "should return the address" do
+        hex_public_key = "b9a152547ec31de50a726896293c7b99e63e6d9588b6d48fde5c926a1794d0616af3598724f335ec71b00509a69e3ce376a285ca5dd77ed5cce8e558c9d5b7e7"
+
+        public_key = PublicKey.from(hex_public_key)
+        public_key.address.should eq("TTA5YjVkYTA1NWVkNWQyNDYyMmNiMWU5M2EwZWVhZmFmODA4MDg3MjU5NzAxNTll")
+      end
+
+      it "should return a mainnet address" do
+        keys = Keys.generate
+        decoded_address = Base64.decode_string(keys.public_key.address)
+        decoded_address[0..1].should eq("M0")
+      end
+
+      it "should return a testnet address" do
+        keys = Keys.generate({prefix: "T0", name: "testnet"})
+        decoded_address = Base64.decode_string(keys.public_key.address)
+        decoded_address[0..1].should eq("T0")
+      end
     end
 
     describe "#is_valid?" do
       it "should return true if the public key is valid" do
-      end
-      it "should return false if the public key is invalid" do
+        # will always be true when called externally since we raise an error creating a public key with an invalid hex
+        # however when called internally we use this to determine if the supplied hex is valid when creating a public key
+        # so we can't test the false condition here.
+        Keys.generate.public_key.is_valid?.should be_true
       end
     end
   end

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -5,12 +5,42 @@ include Sushi::Core
 include Sushi::Core::Keys
 
 describe Keys do
-
   describe PublicKey do
+    describe "#initialize" do
+      it "should create a public key object from a public key string" do
+        public_key = PublicKey.new("")
+      end
 
-   it "should create a public key object from a public key x and y" do
-   end
+      it "should raise an error if the public key string is not a valid public key" do
+      end
+    end
 
+    describe "#from hex" do
+      it "should create a public key object from a public key string" do
+      end
+    end
+
+    describe "#from bytes" do
+      it "should create a public key object from a public key byte array" do
+      end
+      it "should raise an error if the public key byte array is not a valid public key" do
+      end
+    end
+
+    it "should convert a public key from hex to bytes with #as_bytes" do
+    end
+
+    it "should convert a public key from bytes to hex with #as_hex" do
+    end
+
+    it "should return the address with #address" do
+    end
+
+    describe "#is_valid?" do
+      it "should return true if the public key is valid" do
+      end
+      it "should return false if the public key is invalid" do
+      end
+    end
   end
-
 end

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -230,4 +230,5 @@ describe Keys do
       end
     end
   end
+    STDERR.puts "< Keys"
 end

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -130,4 +130,104 @@ describe Keys do
       end
     end
   end
+
+  describe PrivateKey do
+    describe "#initialize" do
+      it "should create a private key object from a private key string" do
+        secp256k1 = ECDSA::Secp256k1.new
+        key_pair = secp256k1.create_key_pair
+        hex_private_key = key_pair[:secret_key].to_s(16)
+
+        private_key = PrivateKey.new(hex_private_key)
+        private_key.as_hex.should eq(hex_private_key)
+      end
+
+      it "should raise an error if the private key hex string is not a valid private key" do
+        expect_raises(Exception, "Invalid private key: 123") do
+          PrivateKey.new("123")
+        end
+      end
+    end
+
+    describe "#from hex" do
+      it "should create a private key object from a private key string" do
+        secp256k1 = ECDSA::Secp256k1.new
+        key_pair = secp256k1.create_key_pair
+        hex_private_key = key_pair[:secret_key].to_s(16)
+
+        private_key = PrivateKey.from(hex_private_key)
+        private_key.as_hex.should eq(hex_private_key)
+      end
+    end
+
+    describe "#from bytes" do
+      it "should create a private key object from a private key byte array" do
+        secp256k1 = ECDSA::Secp256k1.new
+        key_pair = secp256k1.create_key_pair
+        hex_private_key = key_pair[:secret_key].to_s(16)
+        hexbytes = hex_private_key.hexbytes
+
+        private_key = PrivateKey.from(hexbytes)
+        private_key.as_bytes.should eq(hexbytes)
+        private_key.as_hex.should eq(hex_private_key)
+      end
+    end
+
+    it "should convert a private key from hex to bytes with #as_bytes" do
+      secp256k1 = ECDSA::Secp256k1.new
+      key_pair = secp256k1.create_key_pair
+      hex_private_key = key_pair[:secret_key].to_s(16)
+      hexbytes = hex_private_key.hexbytes
+
+      private_key = PrivateKey.from(hex_private_key)
+      private_key.as_bytes.should eq(hexbytes)
+    end
+
+    it "should convert a private key from bytes to hex with #as_hex" do
+      secp256k1 = ECDSA::Secp256k1.new
+      key_pair = secp256k1.create_key_pair
+      hex_private_key = key_pair[:secret_key].to_s(16)
+      hexbytes = hex_private_key.hexbytes
+
+      private_key = PrivateKey.from(hexbytes)
+      private_key.as_hex.should eq(hex_private_key)
+    end
+
+    describe "#network" do
+      it "should return the mainnet by default" do
+        Keys.generate.private_key.network.should eq({prefix: "M0", name: "mainnet"})
+      end
+      it "should return the supplied network" do
+        Keys.generate({prefix: "T0", name: "testnet"}).private_key.network.should eq({prefix: "T0", name: "testnet"})
+      end
+    end
+
+    describe "#address" do
+      it "should return the address" do
+        hex_private_key = "5509e2f567bbe25ef90d2682e3fed09266117ce493438a3c20c05b34293a29a6"
+
+        private_key = PrivateKey.from(hex_private_key)
+        private_key.address.should eq("TTA0YTQzZDQ1M2UwNzdlZDA5YTI1NGYxZGNiNTNhYmY0OTE4NmEyMzg5YTJmMGI0")
+      end
+
+      it "should return a mainnet address" do
+        keys = Keys.generate
+        decoded_address = Base64.decode_string(keys.private_key.address)
+        decoded_address[0..1].should eq("M0")
+      end
+
+      it "should return a testnet address" do
+        keys = Keys.generate({prefix: "T0", name: "testnet"})
+        decoded_address = Base64.decode_string(keys.private_key.address)
+        decoded_address[0..1].should eq("T0")
+      end
+    end
+
+    describe "#is_valid?" do
+      it "should return true if the public key is valid" do
+        # See comment on PublicKey #is_valid? same applies here
+        Keys.generate.private_key.is_valid?.should be_true
+      end
+    end
+  end
 end

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -1,0 +1,16 @@
+require "./../../spec_helper"
+require "./../utils"
+
+include Sushi::Core
+include Sushi::Core::Keys
+
+describe Keys do
+
+  describe PublicKey do
+
+   it "should create a public key object from a public key x and y" do
+   end
+
+  end
+
+end

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -8,7 +8,12 @@ describe Keys do
   describe PublicKey do
     describe "#initialize" do
       it "should create a public key object from a public key string" do
-        public_key = PublicKey.new("")
+        secp256k1 = ECDSA::Secp256k1.new
+        key_pair = secp256k1.create_key_pair
+        hex_public_key = key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16)
+
+        public_key = PublicKey.new(hex_public_key)
+        public_key.as_hex.should eq(hex_public_key)
       end
 
       it "should raise an error if the public key string is not a valid public key" do
@@ -17,11 +22,39 @@ describe Keys do
 
     describe "#from hex" do
       it "should create a public key object from a public key string" do
+        secp256k1 = ECDSA::Secp256k1.new
+
+
+         loop do
+             key_pair = secp256k1.create_key_pair
+             one = key_pair[:public_key].x.to_s(16)
+             p two = key_pair[:public_key].y.to_s(16)
+             sk = key_pair[:secret_key].to_s(16)
+             # p sk.size
+             # p one.size
+             # p two.size
+            hex_public_key = one + two
+            if hex_public_key.hexbytes? == nil
+              puts "is not hex: #{hex_public_key}"
+              break
+            end
+         end
+
+        # public_key = PublicKey.from(hex_public_key)
+        # public_key.as_hex.should eq(hex_public_key)
       end
     end
 
     describe "#from bytes" do
       it "should create a public key object from a public key byte array" do
+        secp256k1 = ECDSA::Secp256k1.new
+        key_pair = secp256k1.create_key_pair
+        hex_public_key = key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16)
+        hexbytes = hex_public_key.hexbytes
+        # p typeof(hexbytes)
+        public_key = PublicKey.from(hexbytes)
+        public_key.as_bytes.should eq(hexbytes)
+        public_key.as_hex.should eq(hex_public_key)
       end
       it "should raise an error if the public key byte array is not a valid public key" do
       end

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -25,6 +25,16 @@ describe Keys do
       keys = Keys.generate({prefix: "T0", name: "testnet"})
       keys.public_key.network.should eq({prefix: "T0", name: "testnet"})
     end
+
+    it "should make a wif for mainnet when no network supplied" do
+      keys = Keys.generate
+      keys.wif.network.should eq({prefix: "M0", name: "mainnet"})
+    end
+
+    it "should make a wif for the specified network" do
+      keys = Keys.generate({prefix: "T0", name: "testnet"})
+      keys.wif.network.should eq({prefix: "T0", name: "testnet"})
+    end
   end
 
   describe PublicKey do
@@ -105,18 +115,18 @@ describe Keys do
         hex_public_key = "b9a152547ec31de50a726896293c7b99e63e6d9588b6d48fde5c926a1794d0616af3598724f335ec71b00509a69e3ce376a285ca5dd77ed5cce8e558c9d5b7e7"
 
         public_key = PublicKey.from(hex_public_key)
-        public_key.address.should eq("TTA5YjVkYTA1NWVkNWQyNDYyMmNiMWU5M2EwZWVhZmFmODA4MDg3MjU5NzAxNTll")
+        public_key.address.as_hex.should eq("TTA5YjVkYTA1NWVkNWQyNDYyMmNiMWU5M2EwZWVhZmFmODA4MDg3MjU5NzAxNTll")
       end
 
       it "should return a mainnet address" do
         keys = Keys.generate
-        decoded_address = Base64.decode_string(keys.public_key.address)
+        decoded_address = Base64.decode_string(keys.public_key.address.as_hex)
         decoded_address[0..1].should eq("M0")
       end
 
       it "should return a testnet address" do
         keys = Keys.generate({prefix: "T0", name: "testnet"})
-        decoded_address = Base64.decode_string(keys.public_key.address)
+        decoded_address = Base64.decode_string(keys.public_key.address.as_hex)
         decoded_address[0..1].should eq("T0")
       end
     end
@@ -207,18 +217,18 @@ describe Keys do
         hex_private_key = "5509e2f567bbe25ef90d2682e3fed09266117ce493438a3c20c05b34293a29a6"
 
         private_key = PrivateKey.from(hex_private_key)
-        private_key.address.should eq("TTA0YTQzZDQ1M2UwNzdlZDA5YTI1NGYxZGNiNTNhYmY0OTE4NmEyMzg5YTJmMGI0")
+        private_key.address.as_hex.should eq("TTA0YTQzZDQ1M2UwNzdlZDA5YTI1NGYxZGNiNTNhYmY0OTE4NmEyMzg5YTJmMGI0")
       end
 
       it "should return a mainnet address" do
         keys = Keys.generate
-        decoded_address = Base64.decode_string(keys.private_key.address)
+        decoded_address = Base64.decode_string(keys.private_key.address.as_hex)
         decoded_address[0..1].should eq("M0")
       end
 
       it "should return a testnet address" do
         keys = Keys.generate({prefix: "T0", name: "testnet"})
-        decoded_address = Base64.decode_string(keys.private_key.address)
+        decoded_address = Base64.decode_string(keys.private_key.address.as_hex)
         decoded_address[0..1].should eq("T0")
       end
     end

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -139,6 +139,7 @@ describe Keys do
         decoded_address = Base64.decode_string(keys.public_key.address.as_hex)
         decoded_address[0..1].should eq("T0")
       end
+
     end
 
     describe "#is_valid?" do
@@ -310,5 +311,28 @@ describe Keys do
       end
     end
   end
+
+  describe Address do
+
+    it "should create an address object from a hex string" do
+      address_hex = "TTBkYzI1OGY3MWY5YTNjZTU5Zjg4ZGJlNjI1ODUxNmU3OTY3MDg4NGE1MDU2YzE0"
+      address = Address.new(address_hex)
+      address.as_hex.should eq(address_hex)
+    end
+
+    it "should raise an error if address checksum is not valid" do
+    end
+
+    it "should return the network when calling #network" do
+      Keys.generate.address.network.should eq({prefix: "M0", name: "mainnet"})
+    end
+
+    it "should return true for #is_valid?" do
+      # NOTE a return value of false is not possible as Address can't be created when invalid
+      Keys.generate.address.is_valid?.should be_true
+    end
+
+  end
+
     STDERR.puts "< Keys"
 end

--- a/spec/units/blockchain/keys.cr
+++ b/spec/units/blockchain/keys.cr
@@ -250,5 +250,65 @@ describe Keys do
       end
     end
   end
+
+  describe Wif do
+    describe "#initialize" do
+      it "should create a wif key object from a wif hex string" do
+        wif_hex = "TTA4YWM5MzAzYjIxZWYyMjU3M2Q3ODQ0ZmFlNDI1ZjdmMGYxOTNjMzIyNjBiYzVmMzQ0MTUxMjA4ZmI1MzAzNTk0NTJiOWNi"
+        Wif.new(wif_hex).as_hex.should eq(wif_hex)
+      end
+
+      it "should raise an error if the private key hex string is not a valid private key" do
+        expect_raises(Exception, "Invalid wif: 123") do
+          Wif.new("123")
+        end
+      end
+    end
+
+    describe "#from hex" do
+      it "should create a wif object from a private key string" do
+        hex_private_key = "f92913f355539a6ec6129b744a9e1dcb4d3c8df29cccb8066d57c454cead6fe4"
+
+        wif = PrivateKey.from(hex_private_key).wif
+        wif.as_hex.should eq("TTBmOTI5MTNmMzU1NTM5YTZlYzYxMjliNzQ0YTllMWRjYjRkM2M4ZGYyOWNjY2I4MDY2ZDU3YzQ1NGNlYWQ2ZmU0MjdlYzNl")
+      end
+    end
+
+    it "should return the public key when calling #public_key" do
+      keys = Keys.generate
+      keys.wif.public_key.as_hex.should eq(keys.public_key.as_hex)
+    end
+
+    it "should return the private key when calling #private_key" do
+      keys = Keys.generate
+      keys.wif.private_key.as_hex.should eq(keys.private_key.as_hex)
+    end
+
+    describe "#network" do
+      it "should return the mainnet by default" do
+        Keys.generate.wif.network.should eq({prefix: "M0", name: "mainnet"})
+      end
+      it "should return the supplied network" do
+        Keys.generate({prefix: "T0", name: "testnet"}).wif.network.should eq({prefix: "T0", name: "testnet"})
+      end
+    end
+
+    describe "#address" do
+      it "should return the address" do
+        hex_private_key = "5509e2f567bbe25ef90d2682e3fed09266117ce493438a3c20c05b34293a29a6"
+        private_key = PrivateKey.from(hex_private_key)
+
+        wif = private_key.wif
+        wif.address.as_hex.should eq("TTA0YTQzZDQ1M2UwNzdlZDA5YTI1NGYxZGNiNTNhYmY0OTE4NmEyMzg5YTJmMGI0")
+      end
+    end
+
+    describe "#is_valid?" do
+      it "should return true if the wif is valid" do
+        # See comment on PublicKey #is_valid? same applies here
+        Keys.generate.wif.is_valid?.should be_true
+      end
+    end
+  end
     STDERR.puts "< Keys"
 end

--- a/spec/units/blockchain/wallet.cr
+++ b/spec/units/blockchain/wallet.cr
@@ -1,3 +1,6 @@
+require "./../../spec_helper"
+require "./../utils"
+
 include Sushi::Core
 include Hashes
 

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -21,13 +21,13 @@ module ::Sushi::Core::Keys
   end
 
   class Address
-    getter network
+    getter network : Network
 
     def initialize(hex_address : String, @network : Network = {prefix: "M0", name: "mainnet"})
       @hex = hex_address
     end
 
-    def as_hex
+    def as_hex : String
       @hex
     end
   end

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -11,7 +11,7 @@ module ::Sushi::Core::Keys
       PublicKey.new(hex)
     end
 
-    def self.from(bytes : Array(UInt8)) : PublicKey
+    def self.from(bytes : Bytes) : PublicKey
       PublicKey.new(to_hex(bytes))
     end
 
@@ -19,11 +19,14 @@ module ::Sushi::Core::Keys
       @hex
     end
 
-    def as_bytes : Array(UInt8)
+    def as_bytes : Bytes
       to_bytes(@hex)
     end
 
     def address : String
+      secp256k1 = ECDSA::Secp256k1.new
+      p secp256k1.create_key_pair(self.as_bytes)
+      ""
     end
 
     def is_valid? : Bool
@@ -41,7 +44,7 @@ module ::Sushi::Core::Keys
       PrivateKey.new(hex)
     end
 
-    def self.from(bytes : Array(UInt8)) : PrivateKey
+    def self.from(bytes : Bytes) : PrivateKey
         PrivateKey.new(to_hex(bytes))
     end
 
@@ -49,7 +52,7 @@ module ::Sushi::Core::Keys
       @hex
     end
 
-    def as_bytes : Array(UInt8)
+    def as_bytes : Bytes
       to_bytes(@hex)
     end
 
@@ -102,10 +105,12 @@ module ::Sushi::Core::Keys
   end
 
 
-  def to_hex(bytes) : String
+  def to_hex(bytes : Bytes) : String
+    bytes.to_unsafe.to_slice(bytes.size).hexstring
   end
 
-  def to_bytes(hex) : Array(UInt8)
+  def to_bytes(hex : String) : Bytes
+    hex.hexbytes
   end
 
 end

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -3,7 +3,7 @@ module ::Sushi::Core::Keys
 
   class PublicKey
 
-    def initalize(hex : String)
+    def initialize(hex : String)
       @hex = hex
     end
 
@@ -33,7 +33,7 @@ module ::Sushi::Core::Keys
 
   class PrivateKey
 
-    def initalize(hex : String)
+    def initialize(hex : String)
       @hex = hex
     end
 

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -6,8 +6,9 @@ module ::Sushi::Core::Keys
     getter private_key : PrivateKey
     getter public_key : PublicKey
     getter wif : Wif
+    getter address : Address
 
-    def initialize(@private_key : PrivateKey, @public_key : PublicKey, @wif : Wif)
+    def initialize(@private_key : PrivateKey, @public_key : PublicKey, @wif : Wif, @address : Address)
     end
 
     def self.generate(network : Network = {prefix: "M0", name: "mainnet"})
@@ -15,7 +16,7 @@ module ::Sushi::Core::Keys
       key_pair = secp256k1.create_key_pair
       private_key = PrivateKey.new(key_pair[:secret_key].to_s(16), network)
       public_key = PublicKey.new(key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16), network)
-      Keys.new(private_key, public_key, Wif.from(private_key, network))
+      Keys.new(private_key, public_key, Wif.from(private_key, network), public_key.address)
     end
   end
 

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -1,18 +1,37 @@
 module ::Sushi::Core::Keys
-  extend Hashes
+  include Hashes
+  include Sushi::Core::Models
+
+  class Keys
+    property private_key : PrivateKey
+    property public_key : PublicKey
+
+    def initialize(@private_key : PrivateKey, @public_key : PublicKey)
+    end
+
+    def self.generate(network : Network = {prefix: "M0", name: "mainnet"})
+      secp256k1 = ECDSA::Secp256k1.new
+      key_pair = secp256k1.create_key_pair
+      private_key = PrivateKey.new(key_pair[:secret_key].to_s(16))
+      public_key = PublicKey.new(key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16), network)
+      Keys.new(private_key, public_key)
+    end
+  end
 
   class PublicKey
+    getter network
 
-    def initialize(hex : String)
+    def initialize(hex : String, @network : Network = {prefix: "M0", name: "mainnet"})
       @hex = hex
+      raise "Invalid public key: #{@hex}" unless is_valid?
     end
 
-    def self.from(hex : String) : PublicKey
-      PublicKey.new(hex)
+    def self.from(hex : String, network : Network = {prefix: "M0", name: "mainnet"}) : PublicKey
+      PublicKey.new(hex, network)
     end
 
-    def self.from(bytes : Bytes) : PublicKey
-      PublicKey.new(to_hex(bytes))
+    def self.from(bytes : Bytes, network : Network = {prefix: "M0", name: "mainnet"}) : PublicKey
+      PublicKey.new(to_hex(bytes), network)
     end
 
     def as_hex : String
@@ -24,18 +43,19 @@ module ::Sushi::Core::Keys
     end
 
     def address : String
-      secp256k1 = ECDSA::Secp256k1.new
-      p secp256k1.create_key_pair(self.as_bytes)
-      ""
+      hashed_address = ripemd160(sha256(@hex))
+      network_address = @network[:prefix] + hashed_address
+      hashed_address_again = sha256(sha256(network_address))
+      checksum = hashed_address_again[0..5]
+      Base64.strict_encode(network_address + checksum)
     end
 
     def is_valid? : Bool
+      @hex.hexbytes? != nil
     end
-
   end
 
   class PrivateKey
-
     def initialize(hex : String)
       @hex = hex
     end
@@ -45,7 +65,7 @@ module ::Sushi::Core::Keys
     end
 
     def self.from(bytes : Bytes) : PrivateKey
-        PrivateKey.new(to_hex(bytes))
+      PrivateKey.new(to_hex(bytes))
     end
 
     def as_hex : String
@@ -70,12 +90,9 @@ module ::Sushi::Core::Keys
 
     def is_valid? : Bool
     end
-
   end
 
-
   class Wif
-
     def initialize(private_key : PrivateKey, network : Network)
       @wif = to_wif(private_key, network)
     end
@@ -101,9 +118,7 @@ module ::Sushi::Core::Keys
 
     private def to_wif(private_key : PrivateKey, network : Network) : Wif
     end
-
   end
-
 
   def to_hex(bytes : Bytes) : String
     bytes.to_unsafe.to_slice(bytes.size).hexstring
@@ -112,5 +127,4 @@ module ::Sushi::Core::Keys
   def to_bytes(hex : String) : Bytes
     hex.hexbytes
   end
-
 end

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -25,10 +25,20 @@ module ::Sushi::Core::Keys
 
     def initialize(hex_address : String, @network : Network = {prefix: "M0", name: "mainnet"})
       @hex = hex_address
+      raise "Invalid address checksum for: #{@hex}" unless is_valid?
     end
 
     def as_hex : String
       @hex
+    end
+
+    def is_valid?
+      decoded_address = Base64.decode_string(@hex)
+      return false unless decoded_address.size == 48
+      version_address = decoded_address[0..-7]
+      hashed_address = sha256(sha256(version_address))
+      checksum = decoded_address[-6..-1]
+      checksum == hashed_address[0..5]
     end
   end
 

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -12,7 +12,7 @@ module ::Sushi::Core::Keys
     def self.generate(network : Network = {prefix: "M0", name: "mainnet"})
       secp256k1 = ECDSA::Secp256k1.new
       key_pair = secp256k1.create_key_pair
-      private_key = PrivateKey.new(key_pair[:secret_key].to_s(16))
+      private_key = PrivateKey.new(key_pair[:secret_key].to_s(16), network)
       public_key = PublicKey.new(key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16), network)
       Keys.new(private_key, public_key)
     end
@@ -47,7 +47,7 @@ module ::Sushi::Core::Keys
     end
 
     def is_valid? : Bool
-      @hex.hexbytes? != nil
+      @hex.hexbytes? != nil && @hex.size == 128
     end
   end
 
@@ -56,7 +56,7 @@ module ::Sushi::Core::Keys
 
     def initialize(hex : String, @network : Network = {prefix: "M0", name: "mainnet"})
       @hex = hex
-      raise "Invalid public key: #{@hex}" unless is_valid?
+      raise "Invalid private key: #{@hex}" unless is_valid?
     end
 
     def self.from(hex : String, network : Network = {prefix: "M0", name: "mainnet"}) : PrivateKey
@@ -92,7 +92,7 @@ module ::Sushi::Core::Keys
     end
 
     def is_valid? : Bool
-      @hex.hexbytes? != nil
+      @hex.hexbytes? != nil && @hex.size == 64
     end
   end
 
@@ -120,7 +120,7 @@ module ::Sushi::Core::Keys
     def address : String
     end
 
-    private def to_wif(private_key : PrivateKey, network : Network) : Wif
+    private def to_wif(private_key : PrivateKey, network : Network = {prefix: "M0", name: "mainnet"}) : Wif
     end
   end
 

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -19,7 +19,7 @@ module ::Sushi::Core::Keys
   end
 
   class PublicKey
-    getter network
+    getter network : Network
 
     def initialize(hex : String, @network : Network = {prefix: "M0", name: "mainnet"})
       @hex = hex
@@ -43,11 +43,7 @@ module ::Sushi::Core::Keys
     end
 
     def address : String
-      hashed_address = ripemd160(sha256(@hex))
-      network_address = @network[:prefix] + hashed_address
-      hashed_address_again = sha256(sha256(network_address))
-      checksum = hashed_address_again[0..5]
-      Base64.strict_encode(network_address + checksum)
+      get_address_from_public_key(self)
     end
 
     def is_valid? : Bool
@@ -56,16 +52,19 @@ module ::Sushi::Core::Keys
   end
 
   class PrivateKey
-    def initialize(hex : String)
+    getter network : Network
+
+    def initialize(hex : String, @network : Network = {prefix: "M0", name: "mainnet"})
       @hex = hex
+      raise "Invalid public key: #{@hex}" unless is_valid?
     end
 
-    def self.from(hex : String) : PrivateKey
-      PrivateKey.new(hex)
+    def self.from(hex : String, network : Network = {prefix: "M0", name: "mainnet"}) : PrivateKey
+      PrivateKey.new(hex, network)
     end
 
-    def self.from(bytes : Bytes) : PrivateKey
-      PrivateKey.new(to_hex(bytes))
+    def self.from(bytes : Bytes, network : Network = {prefix: "M0", name: "mainnet"}) : PrivateKey
+      PrivateKey.new(to_hex(bytes), network)
     end
 
     def as_hex : String
@@ -79,16 +78,21 @@ module ::Sushi::Core::Keys
     def wif : Wif
     end
 
-    def private_key : PrivateKey
-    end
-
     def public_key : PublicKey
+      secp256k1 = ECDSA::Secp256k1.new
+      key_pair = secp256k1.create_key_pair(@hex.to_big_i(16))
+
+      raise "Private key mismatch when finding public key" unless key_pair[:secret_key].to_s(16) == @hex
+
+      PublicKey.new(key_pair[:public_key].x.to_s(16) + key_pair[:public_key].y.to_s(16), @network)
     end
 
     def address : String
+      get_address_from_public_key(self.public_key)
     end
 
     def is_valid? : Bool
+      @hex.hexbytes? != nil
     end
   end
 
@@ -126,5 +130,13 @@ module ::Sushi::Core::Keys
 
   def to_bytes(hex : String) : Bytes
     hex.hexbytes
+  end
+
+  def get_address_from_public_key(public_key : PublicKey)
+    hashed_address = ripemd160(sha256(public_key.as_hex))
+    network_address = public_key.network[:prefix] + hashed_address
+    hashed_address_again = sha256(sha256(network_address))
+    checksum = hashed_address_again[0..5]
+    Base64.strict_encode(network_address + checksum)
   end
 end

--- a/src/core/blockchain/keys.cr
+++ b/src/core/blockchain/keys.cr
@@ -1,0 +1,111 @@
+module ::Sushi::Core::Keys
+  extend Hashes
+
+  class PublicKey
+
+    def initalize(hex : String)
+      @hex = hex
+    end
+
+    def self.from(hex : String) : PublicKey
+      PublicKey.new(hex)
+    end
+
+    def self.from(bytes : Array(UInt8)) : PublicKey
+      PublicKey.new(to_hex(bytes))
+    end
+
+    def as_hex : String
+      @hex
+    end
+
+    def as_bytes : Array(UInt8)
+      to_bytes(@hex)
+    end
+
+    def address : String
+    end
+
+    def is_valid? : Bool
+    end
+
+  end
+
+  class PrivateKey
+
+    def initalize(hex : String)
+      @hex = hex
+    end
+
+    def self.from(hex : String) : PrivateKey
+      PrivateKey.new(hex)
+    end
+
+    def self.from(bytes : Array(UInt8)) : PrivateKey
+        PrivateKey.new(to_hex(bytes))
+    end
+
+    def as_hex : String
+      @hex
+    end
+
+    def as_bytes : Array(UInt8)
+      to_bytes(@hex)
+    end
+
+    def wif : Wif
+    end
+
+    def private_key : PrivateKey
+    end
+
+    def public_key : PublicKey
+    end
+
+    def address : String
+    end
+
+    def is_valid? : Bool
+    end
+
+  end
+
+
+  class Wif
+
+    def initialize(private_key : PrivateKey, network : Network)
+      @wif = to_wif(private_key, network)
+    end
+
+    def self.from(private_key : PrivateKey, network : Network) : Wif
+      Wif.new(private_key, network)
+    end
+
+    def self.from(wif : String) : Wif
+    end
+
+    def private_key : PrivateKey
+    end
+
+    def public_key : PublicKey
+    end
+
+    def network : Network
+    end
+
+    def address : String
+    end
+
+    private def to_wif(private_key : PrivateKey, network : Network) : Wif
+    end
+
+  end
+
+
+  def to_hex(bytes) : String
+  end
+
+  def to_bytes(hex) : Array(UInt8)
+  end
+
+end

--- a/src/core/ecdsa/group.cr
+++ b/src/core/ecdsa/group.cr
@@ -22,7 +22,15 @@ module ::Sushi::Core::ECDSA
       return create_key_pair if secret_key.to_s(16).hexbytes? == nil
 
       key_pair = create_key_pair(secret_key)
-      if key_pair[:public_key].x.to_s(16).hexbytes? == nil || key_pair[:public_key].y.to_s(16).hexbytes? == nil
+
+      x = key_pair[:public_key].x.to_s(16)
+      y = key_pair[:public_key].y.to_s(16)
+
+      if x.hexbytes? == nil || y.hexbytes? == nil
+        return create_key_pair
+      end
+
+      if x.size != 64 || y.size != 64
         return create_key_pair
       end
 

--- a/src/core/ecdsa/group.cr
+++ b/src/core/ecdsa/group.cr
@@ -16,12 +16,17 @@ module ::Sushi::Core::ECDSA
     end
 
     def create_key_pair
-      random_key = Random::Secure.hex(64)
-
-      return create_key_pair if random_key[0] == '0'
-
+      random_key = Random::Secure.hex(32)
       secret_key = BigInt.new(random_key, base: 16)
-      create_key_pair(secret_key)
+
+      return create_key_pair if secret_key.to_s(16).hexbytes? == nil
+
+      key_pair = create_key_pair(secret_key)
+      if key_pair[:public_key].x.to_s(16).hexbytes? == nil || key_pair[:public_key].y.to_s(16).hexbytes? == nil
+        return create_key_pair
+      end
+
+      key_pair
     end
 
     def create_key_pair(secret_key : BigInt)

--- a/src/core/ecdsa/group.cr
+++ b/src/core/ecdsa/group.cr
@@ -19,7 +19,8 @@ module ::Sushi::Core::ECDSA
       random_key = Random::Secure.hex(32)
       secret_key = BigInt.new(random_key, base: 16)
 
-      return create_key_pair if secret_key.to_s(16).hexbytes? == nil
+      secret_key_hex = secret_key.to_s(16)
+      return create_key_pair if secret_key_hex.hexbytes? == nil || secret_key_hex.size != 64
 
       key_pair = create_key_pair(secret_key)
 


### PR DESCRIPTION
This lays the foundation to refactor Wallet.cr - to provide a single public_key, wif, and encrypted wallet

lets you handle keys as objects e.g.

```
keys = Keys.generate
keys.public_key - returns PublicKey
keys.private_key - returns PrivateKey 
keys.wif - returns Wif
keys.address - returns Address

# each has various methods on them

keys.public_key.address.network - returns the network for the address
keys.private_key.wif.as_hex - returns hex string of wif from private key
```

There are conversions between hex and bytes and access to network, address, public keys, private keys etc