### PR TITLE
fixing cors issue and fixing json rpc

### DIFF
--- a/spec/units/node/rpc_controller.cr
+++ b/spec/units/node/rpc_controller.cr
@@ -82,7 +82,7 @@ describe RPCController do
 
           payload = {
             call:        "create_transaction",
-            transaction: signed_transaction.to_json,
+            transaction: signed_transaction,
           }.to_json
 
           json = JSON.parse(payload)

--- a/spec/units/node/rpc_controller.cr
+++ b/spec/units/node/rpc_controller.cr
@@ -18,8 +18,8 @@ describe RPCController do
           payload = {
             call:       "create_unsigned_transaction",
             action:     "send",
-            senders:    senders.to_json,
-            recipients: recipients.to_json,
+            senders:    senders,
+            recipients: recipients,
             message:    "",
           }.to_json
 
@@ -46,8 +46,8 @@ describe RPCController do
           payload = {
             call:       "create_unsigned_transaction",
             action:     "send",
-            senders:    senders.to_json,
-            recipients: recipients.to_json,
+            senders:    senders,
+            recipients: recipients,
             message:    "",
           }.to_json
 

--- a/src/cli/sushi/transaction.cr
+++ b/src/cli/sushi/transaction.cr
@@ -168,7 +168,7 @@ module ::Sushi::Interface::Sushi
 
       payload = {
         call:        "create_transaction",
-        transaction: signed_transaction.to_json,
+        transaction: signed_transaction,
       }.to_json
 
       rpc(node, payload)

--- a/src/cli/sushi/transaction.cr
+++ b/src/cli/sushi/transaction.cr
@@ -189,8 +189,8 @@ module ::Sushi::Interface::Sushi
       payload = {
         call:       "create_unsigned_transaction",
         action:     action,
-        senders:    senders.to_json,
-        recipients: recipients.to_json,
+        senders:    senders,
+        recipients: recipients,
         message:    message,
       }.to_json
 

--- a/src/core/node.cr
+++ b/src/core/node.cr
@@ -108,7 +108,18 @@ module ::Sushi::Core
     end
 
     private def draw_routes!
-      post "/rpc" { |context, params| @rpc_controller.exec(context, params) }
+      options "/rpc" do |context|
+        context.response.headers["Allow"] = "HEAD,GET,PUT,POST,DELETE,OPTIONS"
+        context.response.headers["Access-Control-Allow-Headers"] = "X-Requested-With, X-HTTP-Method-Override, Content-Type, Cache-Control, Accept"
+        context.response.headers["Access-Control-Allow-Origin"] = "*"
+        context.response.status_code = 200
+        context.response.print ""
+        context
+      end
+      post "/rpc" do |context, params|
+        context.response.headers["Access-Control-Allow-Origin"] = "*"
+        @rpc_controller.exec(context, params)
+      end
       get "/handshake/:salt" { |context, params| @handshake_controller.exec(context, params) }
     end
 

--- a/src/core/node/controllers/rpc_controller.cr
+++ b/src/core/node/controllers/rpc_controller.cr
@@ -32,7 +32,7 @@ module ::Sushi::Core::Controllers
     end
 
     def create_transaction(json, context, params)
-      transaction = Transaction.from_json(json["transaction"].to_s)
+      transaction = Transaction.from_json(json["transaction"].to_json)
       node.broadcast_transaction(transaction)
       context.response.print transaction.to_json
       context

--- a/src/core/node/controllers/rpc_controller.cr
+++ b/src/core/node/controllers/rpc_controller.cr
@@ -44,8 +44,8 @@ module ::Sushi::Core::Controllers
 
     def create_unsigned_transaction(json, context, params)
       action = json["action"].to_s
-      senders = Models::Senders.from_json(json["senders"].to_s)
-      recipients = Models::Recipients.from_json(json["recipients"].to_s)
+      senders = Models::Senders.from_json(json["senders"].to_json)
+      recipients = Models::Recipients.from_json(json["recipients"].to_json)
       message = json["message"].to_s
 
       transaction = @blockchain.create_unsigned_transaction(


### PR DESCRIPTION
This fixes 2 things:

1. fixes the json format of unsigned transaction (senders, recipients) so that a regular json body can be created in javascript or anywhere and posted to the /rpc endpoint

2. fixes CORS (cross origin access) - so that we can post json from locations other than the sushid host via the browser - used for javascript / external wallets