### PR TITLE
Fixing sushim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 sushicoin_profile.sh
 
 .vscode
+.idea

--- a/spec/units/utils/node.cr
+++ b/spec/units/utils/node.cr
@@ -35,7 +35,7 @@ module ::Units::Utils::NodeHelper
     blockchain.replace_chain(chain)
 
     rpc = RPCController.new(blockchain)
-    node = Sushi::Core::Node.new(true, true, "bind_host", 8008_i32, nil, nil, nil, nil, nil, sender_wallet, nil, 1_i32)
+    node = Sushi::Core::Node.new(true, true, "bind_host", 8008_i32, nil, nil, nil, nil, nil, sender_wallet, nil, 1_i32, false)
     rpc.set_node(node)
     yield sender_wallet, recipient_wallet, chain, blockchain, rpc
   end

--- a/src/cli/modules/global_optionparser.cr
+++ b/src/cli/modules/global_optionparser.cr
@@ -27,6 +27,7 @@ module ::Sushi::Interface
     @header : Bool = false
 
     @threads : Int32 = 1
+    @use_ssl : Bool = false
 
     @encrypted : Bool = false
 
@@ -57,6 +58,7 @@ module ::Sushi::Interface
       HEADER = 0x00010000
       # for miners
       THREADS = 0x00100000
+      USE_SSL = 0x00200000
       # for wallet
       ENCRYPTED = 0x01000000
     end
@@ -162,6 +164,10 @@ module ::Sushi::Interface
           @threads = threads.to_i
         } if is_active?(actives, Options::THREADS)
 
+        parser.on("--ssl", "use an ssl endpoint (default is non ssl)") {
+          @use_ssl = true
+        } if is_active?(actives, Options::USE_SSL)
+
         parser.on("-e", "--encrypted", "set this flag when creating a wallet to create an encrypted wallet") {
           @encrypted = true
         } if is_active?(actives, Options::ENCRYPTED)
@@ -266,6 +272,10 @@ module ::Sushi::Interface
       return @threads if @threads != 1
       return cm.get_i32("threads").not_nil! if cm.get_i32("threads")
       @threads
+    end
+
+    def __use_ssl : Bool
+      @use_ssl
     end
 
     def __encrypted : Bool

--- a/src/cli/modules/global_optionparser.cr
+++ b/src/cli/modules/global_optionparser.cr
@@ -27,7 +27,6 @@ module ::Sushi::Interface
     @header : Bool = false
 
     @threads : Int32 = 1
-    @use_ssl : Bool = false
 
     @encrypted : Bool = false
 
@@ -58,7 +57,6 @@ module ::Sushi::Interface
       HEADER = 0x00010000
       # for miners
       THREADS = 0x00100000
-      USE_SSL = 0x00200000
       # for wallet
       ENCRYPTED = 0x01000000
     end
@@ -164,10 +162,6 @@ module ::Sushi::Interface
           @threads = threads.to_i
         } if is_active?(actives, Options::THREADS)
 
-        parser.on("--ssl", "use an ssl endpoint (default is non ssl)") {
-          @use_ssl = true
-        } if is_active?(actives, Options::USE_SSL)
-
         parser.on("-e", "--encrypted", "set this flag when creating a wallet to create an encrypted wallet") {
           @encrypted = true
         } if is_active?(actives, Options::ENCRYPTED)
@@ -272,10 +266,6 @@ module ::Sushi::Interface
       return @threads if @threads != 1
       return cm.get_i32("threads").not_nil! if cm.get_i32("threads")
       @threads
-    end
-
-    def __use_ssl : Bool
-      @use_ssl
     end
 
     def __encrypted : Bool

--- a/src/cli/sushid.cr
+++ b/src/cli/sushid.cr
@@ -39,6 +39,7 @@ module ::Sushi::Interface::SushiD
 
       if connect_node = __connect_node
         connect_uri = URI.parse(connect_node)
+        use_ssl = (connect_uri.scheme == "https")
         has_first_connection = !connect_uri.host.nil? && !connect_uri.port.nil?
       end
 
@@ -52,9 +53,9 @@ module ::Sushi::Interface::SushiD
 
       node = has_first_connection ? Core::Node.new(__is_private, __is_testnet, __bind_host, __bind_port,
         public_host, public_port, ssl,
-        connect_uri.not_nil!.host, connect_uri.not_nil!.port, wallet, database, __conn_min) : Core::Node.new(__is_private, __is_testnet, __bind_host, __bind_port,
+        connect_uri.not_nil!.host, connect_uri.not_nil!.port, wallet, database, __conn_min, use_ssl.not_nil!) : Core::Node.new(__is_private, __is_testnet, __bind_host, __bind_port,
         public_host, public_port, ssl,
-        nil, nil, wallet, database, __conn_min)
+        nil, nil, wallet, database, __conn_min, use_ssl.not_nil!)
       node.run!
     end
 

--- a/src/cli/sushid.cr
+++ b/src/cli/sushid.cr
@@ -36,6 +36,7 @@ module ::Sushi::Interface::SushiD
       end
 
       has_first_connection = false
+      use_ssl = false
 
       if connect_node = __connect_node
         connect_uri = URI.parse(connect_node)
@@ -53,9 +54,9 @@ module ::Sushi::Interface::SushiD
 
       node = has_first_connection ? Core::Node.new(__is_private, __is_testnet, __bind_host, __bind_port,
         public_host, public_port, ssl,
-        connect_uri.not_nil!.host, connect_uri.not_nil!.port, wallet, database, __conn_min, use_ssl.not_nil!) : Core::Node.new(__is_private, __is_testnet, __bind_host, __bind_port,
+        connect_uri.not_nil!.host, connect_uri.not_nil!.port, wallet, database, __conn_min, use_ssl) : Core::Node.new(__is_private, __is_testnet, __bind_host, __bind_port,
         public_host, public_port, ssl,
-        nil, nil, wallet, database, __conn_min, use_ssl.not_nil!)
+        nil, nil, wallet, database, __conn_min, use_ssl)
       node.run!
     end
 

--- a/src/cli/sushim.cr
+++ b/src/cli/sushim.cr
@@ -31,6 +31,9 @@ module ::Sushi::Interface::SushiM
 
       raise "wallet type mismatch" if __is_testnet != wallet_is_testnet
 
+      puts "---------------miner.cr"
+      puts "use_ssl: #{use_ssl}"
+
       miner = Core::Miner.new(__is_testnet, host, port, wallet, __threads, use_ssl)
       miner.run
     end

--- a/src/cli/sushim.cr
+++ b/src/cli/sushim.cr
@@ -13,6 +13,7 @@ module ::Sushi::Interface::SushiM
         Options::WALLET_PASSWORD,
         Options::IS_TESTNET,
         Options::THREADS,
+        Options::USE_SSL
       ])
     end
 
@@ -30,7 +31,7 @@ module ::Sushi::Interface::SushiM
 
       raise "wallet type mismatch" if __is_testnet != wallet_is_testnet
 
-      miner = Core::Miner.new(__is_testnet, host, port, wallet, __threads)
+      miner = Core::Miner.new(__is_testnet, host, port, wallet, __threads, __use_ssl)
       miner.run
     end
 

--- a/src/cli/sushim.cr
+++ b/src/cli/sushim.cr
@@ -31,9 +31,6 @@ module ::Sushi::Interface::SushiM
 
       raise "wallet type mismatch" if __is_testnet != wallet_is_testnet
 
-      puts "---------------miner.cr"
-      puts "use_ssl: #{use_ssl}"
-
       miner = Core::Miner.new(__is_testnet, host, port, wallet, __threads, use_ssl)
       miner.run
     end

--- a/src/cli/sushim.cr
+++ b/src/cli/sushim.cr
@@ -13,7 +13,6 @@ module ::Sushi::Interface::SushiM
         Options::WALLET_PASSWORD,
         Options::IS_TESTNET,
         Options::THREADS,
-        Options::USE_SSL
       ])
     end
 
@@ -22,6 +21,7 @@ module ::Sushi::Interface::SushiM
       puts_help(HELP_CONNECTING_NODE) unless node = __connect_node
 
       node_uri = URI.parse(node)
+      use_ssl = (node_uri.scheme == "https")
 
       puts_help(HELP_CONNECTING_NODE) unless host = node_uri.host
       puts_help(HELP_CONNECTING_NODE) unless port = node_uri.port
@@ -31,7 +31,7 @@ module ::Sushi::Interface::SushiM
 
       raise "wallet type mismatch" if __is_testnet != wallet_is_testnet
 
-      miner = Core::Miner.new(__is_testnet, host, port, wallet, __threads, __use_ssl)
+      miner = Core::Miner.new(__is_testnet, host, port, wallet, __threads, use_ssl)
       miner.run
     end
 

--- a/src/core/miner/miner.cr
+++ b/src/core/miner/miner.cr
@@ -55,7 +55,8 @@ module ::Sushi::Core
     end
 
     def run
-      socket = HTTP::WebSocket.new(@host, "peer", @port)
+      puts "host: #{@host}, port: #{@port}"
+      socket = HTTP::WebSocket.new(@host, "/peer", @port, false)
       socket.on_message do |message|
         message_json = JSON.parse(message)
         message_type = message_json["type"].as_i

--- a/src/core/miner/miner.cr
+++ b/src/core/miner/miner.cr
@@ -56,7 +56,6 @@ module ::Sushi::Core
     end
 
     def run
-      puts "host: #{@host}, port: #{@port}"
       socket = HTTP::WebSocket.new(@host, "/peer", @port, @use_ssl)
       socket.on_message do |message|
         message_json = JSON.parse(message)

--- a/src/core/miner/miner.cr
+++ b/src/core/miner/miner.cr
@@ -6,8 +6,9 @@ module ::Sushi::Core
     @latest_hash : String?
     @latest_nonce : UInt64 = 0_u64 # for debug
     @threads = [] of Thread
+    @use_ssl : Bool
 
-    def initialize(@is_testnet : Bool, @host : String, @port : Int32, @wallet : Wallet, @num_threads : Int32)
+    def initialize(@is_testnet : Bool, @host : String, @port : Int32, @wallet : Wallet, @num_threads : Int32, @use_ssl : Bool)
       info "launching #{@num_threads} threads..."
     end
 
@@ -56,7 +57,7 @@ module ::Sushi::Core
 
     def run
       puts "host: #{@host}, port: #{@port}"
-      socket = HTTP::WebSocket.new(@host, "/peer", @port, false)
+      socket = HTTP::WebSocket.new(@host, "/peer", @port, @use_ssl)
       socket.on_message do |message|
         message_json = JSON.parse(message)
         message_type = message_json["type"].as_i

--- a/src/core/node.cr
+++ b/src/core/node.cr
@@ -36,7 +36,8 @@ module ::Sushi::Core
       connect_port : Int32?,
       @wallet : Wallet,
       @database : Database?,
-      @conn_min : Int32
+      @conn_min : Int32,
+      use_ssl : Bool?
     )
       @id = Random::Secure.hex(16)
       @connection_salt = Random::Secure.hex(16)
@@ -75,17 +76,18 @@ module ::Sushi::Core
       end
 
       if connect_host && connect_port
-        connect(connect_host.not_nil!, connect_port.not_nil!)
+        connect(connect_host.not_nil!, connect_port.not_nil!, use_ssl.not_nil!)
       else
         warning "no connecting node has been specified"
         warning "so this node is standalone from other network"
       end
     end
 
-    private def connect(connect_host : String, connect_port : Int32)
+    private def connect(connect_host : String, connect_port : Int32, use_ssl : Bool = false)
       info "connecting to #{light_green(connect_host)}:#{light_green(connect_port)}"
+      info "detected an https connecting node - switching to SSL" if use_ssl
 
-      socket = HTTP::WebSocket.new(connect_host, "/peer", connect_port)
+      socket = HTTP::WebSocket.new(connect_host, "/peer", connect_port, use_ssl)
 
       peer(socket)
 

--- a/src/core/node.cr
+++ b/src/core/node.cr
@@ -37,7 +37,7 @@ module ::Sushi::Core
       @wallet : Wallet,
       @database : Database?,
       @conn_min : Int32,
-      use_ssl : Bool
+      @use_ssl : Bool = false
     )
       @id = Random::Secure.hex(16)
       @connection_salt = Random::Secure.hex(16)
@@ -45,6 +45,7 @@ module ::Sushi::Core
       info "id: #{light_green(@id)}"
       info "is_private: #{light_green(@is_private)}"
       info "public url: #{light_green(@public_host)}:#{light_green(@public_port)}" unless @is_private
+      info "connecting node is using ssl?: #{light_green(@use_ssl)}"
 
       @blockchain = Blockchain.new(@wallet, @database)
 
@@ -76,18 +77,18 @@ module ::Sushi::Core
       end
 
       if connect_host && connect_port
-        connect(connect_host.not_nil!, connect_port.not_nil!, use_ssl)
+        connect(connect_host.not_nil!, connect_port.not_nil!)
       else
         warning "no connecting node has been specified"
         warning "so this node is standalone from other network"
       end
     end
 
-    private def connect(connect_host : String, connect_port : Int32, use_ssl : Bool = false)
+    private def connect(connect_host : String, connect_port : Int32)
       info "connecting to #{light_green(connect_host)}:#{light_green(connect_port)}"
-      info "detected an https connecting node - switching to SSL" if use_ssl
+      info "detected an https connecting node - switching to SSL" if @use_ssl
 
-      socket = HTTP::WebSocket.new(connect_host, "/peer", connect_port, use_ssl)
+      socket = HTTP::WebSocket.new(connect_host, "/peer", connect_port, @use_ssl)
 
       peer(socket)
 

--- a/src/core/node.cr
+++ b/src/core/node.cr
@@ -76,7 +76,7 @@ module ::Sushi::Core
       end
 
       if connect_host && connect_port
-        connect(connect_host.not_nil!, connect_port.not_nil!, use_ssl.not_nil!)
+        connect(connect_host.not_nil!, connect_port.not_nil!, use_ssl)
       else
         warning "no connecting node has been specified"
         warning "so this node is standalone from other network"

--- a/src/core/node.cr
+++ b/src/core/node.cr
@@ -37,7 +37,7 @@ module ::Sushi::Core
       @wallet : Wallet,
       @database : Database?,
       @conn_min : Int32,
-      use_ssl : Bool?
+      use_ssl : Bool
     )
       @id = Random::Secure.hex(16)
       @connection_salt = Random::Secure.hex(16)


### PR DESCRIPTION
This provides a fix to the sushim miner so that it can work against http and https endpoints. It autodetects if the connecting node is https to turn on ssl mining. This also provides a fix to allow sushid to connect to an https connecting node - also using autodetection.

with http:
<img width="941" alt="screen shot 2018-03-05 at 21 15 37" src="https://user-images.githubusercontent.com/103770/37000310-eb5828c4-20ba-11e8-9ea3-0de72391a83e.png">

with https:
<img width="935" alt="screen shot 2018-03-05 at 21 52 44" src="https://user-images.githubusercontent.com/103770/37001803-984f7f42-20bf-11e8-9dd6-50de4c09be93.png">

with https sushid:
<img width="938" alt="screen shot 2018-03-05 at 21 51 15" src="https://user-images.githubusercontent.com/103770/37001747-7481ea50-20bf-11e8-804d-de4e065c96eb.png">
